### PR TITLE
Hardcode key to establish anchor of trust

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,10 +3,32 @@
 
 - name: apt-key add
   apt_key:
-    url: "{{ item.url }}"
-    state: "{{ item.state }}"
-  with_items:
-    - { state: "present", url: "http://www.webmin.com/jcameron-key.asc" }
+    state: "present"
+    data: |
+          -----BEGIN PGP PUBLIC KEY BLOCK-----
+          Version: GnuPG v1.0.7 (GNU/Linux)
+
+          mQGiBDx9wR0RBACR3xGPTkG5Staj7EVeiVJDrYXIPF28MGCrOEGw04tQmQTALz0E
+          YEcyfvui7KScrpHmZpy70PwgwxUDPUMik7vvRiUa9RRbJsDYyom06NGk+Z4dURhn
+          DeNRhcBrNBfyMvUY7HSJ2JP9jhQDWb8Lo1i231tvlnY0tNudVsP484ax6wCgrBwW
+          myad6TLYaETj0+AxGJxYgikD/iERqNF60x+WyfEH/SIOuKGlV/QoxmqOePn2gj9V
+          DWiOOAZ9DDWD6DpRNK/UVZRD1MK37HU1ePv7i92DTL9yIbyJwFcZNkEyMU3t+GBj
+          zf4YvaQnvtA09EdQNsC1GXxNXqYkVmTE1dHH83UK+chaXRoDQ6O9KD9SFE2vsj1d
+          z9VPBACPgmuVcUKXag6ZBY+SBColQzwyZfXtTOCnBh0HP4HOjU4G6CRTcAgLQrdM
+          1Uu29Al7TaE2p8HZb37dVoTRntM+Nf5O+2dX5iHA6ncdozKGftuXQMC7z9758nUi
+          2E4Svo9hmroM+NKonpZByt6TilhDXrPIcNYHlNsxpTAxq+lnw7QjSmFtaWUgQ2Ft
+          ZXJvbiA8amNhbWVyb25Ad2VibWluLmNvbT6IVwQTEQIAFwUCPH3BHQULBwoDBAMV
+          AwIDFgIBAheAAAoJENl6OukR9jxRQZEAoIHxngo/LxLBeFF9cpEViVGgChRIAJ90
+          zwqcBfw02su5AavnXjv6HxXF8bkBDQQ8fcEqEAQAx88aO9zI912/tbsNjLhDXpq0
+          WMw5F6fUUlwYpkaspPwWZ3UgDJaR1+oL3xnJKlD1Eu5x9B3r+rxYyoFpXubWz4R6
+          sL1u4kMRb347+fv140dE/RGFNEmqefZDeysz1TQG1Sskyyf7sV2KRUmI8wJTwg3n
+          IOtbyOoE3XlxI5FUrW8AAwUD/iEBdIH5DYB/FnOb/EkP3G3kCXGgTdZk7UA9HPKB
+          dV7JckgSicpi/mX898LxQrr0jyb6nyi2900OgQUQArrviTnp37j4ciQj214gTHzf
+          ssA40O5QR4t915z6wS4Ml+fAc5ZOeL6EQxiP+x+rz6h9+Mc8rawowY+7sBnvVw5O
+          YoVXiEYEGBECAAYFAjx9wSoACgkQ2Xo66RH2PFH+ZgCggAyuOLaoE9t9tyJbifEz
+          /YzvqYwAnj85Ehe8EmnKuor/k/TPtKl4MzDm
+          =oxvD
+          -----END PGP PUBLIC KEY BLOCK-----
   notify: restart webmin
   tags: hswong3i.webmin
 


### PR DESCRIPTION
This improvement includes the literal key (as of now) in order to get a proper chain of trust. Downloading the key via HTTP would be susceptible to a MITM attack.